### PR TITLE
fix: 本文に適用されていた英字をheaderとセクションの見出しにあたるように変更

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "tabWidth": 2
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Montserrat, Noto_Sans_JP } from "next/font/google";
 
 const notoSansJP = Noto_Sans_JP({ subsets: ["latin"], variable: '--font-noto' });
-const mont = Montserrat({subsets: ["latin"], variable: "--font-montserrat", display: "swap"})
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,7 +15,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja" className={`${mont.variable} ${notoSansJP.variable} !scroll-smooth`}>
+    <html lang="ja" className={`${notoSansJP.className} !scroll-smooth`}>
       <body
         className={` bg-gray-50 text-gray-950`}
       >

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -3,13 +3,15 @@ import React from "react";
 import { links } from "@/lib/data";
 import Link from "next/link";
 import {motion} from "framer-motion";
+import { Montserrat, Noto_Sans_JP } from "next/font/google";
+const mont = Montserrat({subsets: ["latin"], variable: "--font-montserrat", display: "swap"})
 export default function Header() {
   return (
     <>
       <motion.header 
       initial={{opacity:0, y:-80}}
       animate={{opacity: 1, y:0}}
-      className="w-[min(1000px,88%)] mx-auto mt-2 h-[80px] flex items-center justify-between px-10 bg-white rounded-xl">
+      className={`${mont.className} w-[min(1000px,88%)] mx-auto mt-2 h-[80px] flex items-center justify-between px-10 bg-white rounded-xl`}>
         <div>
           <a href="/" className="text-3xl">Portfolio</a>
         </div>

--- a/components/sectionHeading.tsx
+++ b/components/sectionHeading.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
+import { Montserrat } from "next/font/google";
+const mont = Montserrat({subsets: ["latin"], variable: "--font-montserrat", display: "swap"})
 interface SectionHeadingProps {
   title: string;
 }
 export default function SectionHeading({title}:SectionHeadingProps) {
   return (
-    <div className='text-3xl font-medium capitalize mb-8 text-center'>{title}</div>
+    <div className={`${mont.className} text-3xl font-medium capitalize mb-8 text-center`}>{title}</div>
   )
 }


### PR DESCRIPTION
close #19 